### PR TITLE
Adds troubleshooting for Azure DevOps PR issues

### DIFF
--- a/gitkraken-desktop/azure-devops.md
+++ b/gitkraken-desktop/azure-devops.md
@@ -95,3 +95,14 @@ GitKraken connects to one Azure DevOps account at a time. However, with a paid G
 In order connect the Azure Devops integrations using OAuth, `Third-party application access via OAuth` will need to be enabled in Azure from `Organization Settings > Policies`. You can find more information on this setting on [Microsoft's Learn Resources](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/change-application-access-policies?view=azure-devops).
 
 If enabling this setting is not possible, you can connect using a Password Access Token.
+
+***
+
+## Azure DevOps Pull Requests form not populating in GitKraken Desktop
+
+When you create a Pull Request with Azure DevOps, it may not populate in Gitkraken Desktop. This is due to the remote URL not using the correct format:
+
+- In the left panel, right-click on your remote (typically origin) and select **Edit**.
+- Edit the URLs and make sure they match the format of your Host Domain URL used to connect via **Preferences > Integrations** (if you are using a PAT) or the URL used to connect via OAuth.
+- Specifically ensure that the format is [organisationname]@dev.azure.com" and **not** the old VSTS format of "[organisationname].visualstudio.com [http://visualstudio.com/]"
+- Click "edit remote" to complete the process

--- a/gitkraken-desktop/pull-requests.md
+++ b/gitkraken-desktop/pull-requests.md
@@ -26,6 +26,11 @@ Or click the <button class='button button--success button--ui button--nolink'>+<
 
 <img src="/wp-content/uploads/create-pr-2025.png" srcset="/wp-content/uploads/create-pr-2025@2x.png" class="help-center-img img-bordered">
 
+<div class='callout callout'>
+  <p><strong>Note:</strong> If you are using Azure DevOps integration, and the Pull Request form is not populating, see this article on [Azure DevOps Integration](/gitkraken-desktop/azure-devops/#azure-devops-pull-requests-form-not-populating-in-gitkraken-desktop) for more information.
+</p>
+</div>
+
 ### Pull request templates
 
 GitKraken Desktop supports pull request templates from your GitHub, GitLab, and Azure DevOps (including legacy VSTS URLs).


### PR DESCRIPTION
Adds documentation to address an issue where Azure DevOps Pull Request forms do not populate in GitKraken Desktop.

- Provides steps to correct the remote URL format, ensuring it matches the format used for connection via Preferences.
- References a dedicated section in the Azure DevOps integration documentation for troubleshooting.