### PR TITLE
Add .env files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 .DS_Store
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local


### PR DESCRIPTION
This PR adds environment variable files to the .gitignore to prevent accidental commit of sensitive configuration data.

Added patterns:
- `.env`
- `.env.local`
- `.env.development.local`
- `.env.test.local`
- `.env.production.local`

This follows security best practices by ensuring environment files containing API keys, database credentials, and other sensitive data are not tracked in version control.