### PR TITLE
Harmonizes on-premises agent documentation

### DIFF
--- a/gitkraken-desktop/agents.md
+++ b/gitkraken-desktop/agents.md
@@ -45,17 +45,18 @@ This page also helps answer common questions such as:
 - Status support: Agent status indicators are available for Claude Code as of version 12.0.0
 - View settings: New agent session worktrees inherit hidden refs, hidden remotes, soloed refs and remotes, and collapsed folders and remotes from the source repository
 - Other agents: You can still run other coding agents manually in the embedded terminal, even if GitKraken does not explicitly integrate with or detect them
+- On-premises environments: Available coding agents may be limited by your organization's security restrictions, internal approvals, or air-gapped network design
 
 | What you want to do | Supported | Where in GitKraken Desktop | Notes |
 |---------------------|-----------|-----------------------------|-------|
 | Start a coding agent session | Yes | Agent Sessions View, or worktree context menu in the Left Panel | Creates a worktree (when starting a new session), runs setup commands, and launches the coding agent CLI |
 | Start multiple coding agent sessions at the same time | Yes | Agent Sessions View | Each session runs in a separate worktree |
 | Choose a different base branch for a new session | Yes | New Agent Session form | Default base branch is `HEAD`. The base branch selector is searchable |
-| Choose a coding agent CLI for a session | Yes | New Agent Session form | Falls back to the coding agent set in Preferences |
+| Choose a coding agent CLI for a session | Yes | New Agent Session form | Falls back to the coding agent set in Preferences. Available options depend on the CLIs installed and allowed in your environment |
 | Monitor agent progress | Yes | Agent Sessions View card | Cards show WIP changes, ahead/behind, and agent status |
 | Respond when an agent is waiting for input | Yes | Agent Sessions View and embedded terminal | Claude Code can show a **Waiting for input** status in the card |
 | Manage a worktree from Agent Sessions View | Yes | Three-dot action menu on each worktree card | Open, lock/unlock, remove, or remove and delete the branch |
-| Configure coding agent CLIs | Yes | <kbd>Preferences > External Tools > Coding Agent</kbd> | GitKraken auto-detects installed CLIs |
+| Configure coding agent CLIs | Yes | <kbd>Preferences > External Tools > Coding Agent</kbd> | GitKraken auto-detects installed CLIs. In on-premises environments, the usable CLIs depend on what your organization allows and can reach |
 | Configure setup commands for a repository | Yes | <kbd>Preferences > Repo-Specific Preferences > Agents</kbd> | Commands run before the agent launches |
 
 ***
@@ -331,9 +332,15 @@ No. They show the same underlying worktrees. The difference is the presentation:
 
 Go to <kbd>Preferences > External Tools > Coding Agent</kbd>. You can also choose a different coding agent in the New Agent Session form for a single session.
 
+### Are all supported coding agents available in on-premises environments?
+
+No. In on-premises environments, available coding agents depend on your organization's security policy, network restrictions, and approved tools.
+
+OpenCode and Gemini CLI can run in fully air-gapped environments when they are configured to use an internal model endpoint. Claude Code, Codex CLI, and Copilot CLI are also supported when your organization permits them and the required services are reachable.
+
 ### Can I use a coding agent that GitKraken Desktop does not explicitly integrate with?
 
-Yes. GitKraken Desktop explicitly integrates with supported coding agent CLIs such as Claude Code, Codex CLI, Copilot CLI, Gemini CLI, and OpenCode, but you can still run other coding agents manually in the embedded terminal. The agent does not need to appear in the coding agent configuration for you to use that terminal workflow.
+Yes. GitKraken Desktop explicitly integrates with supported coding agent CLIs such as Claude Code, Codex CLI, Copilot CLI, Gemini CLI, and OpenCode, but you can still run other coding agents manually in the embedded terminal. The agent does not need to appear in the coding agent configuration for you to use that terminal workflow. In on-premises environments, this manual path is often the best option for internally approved tools that are not part of the built-in list.
 
 ### Where do I configure repository setup before the agent starts?
 

--- a/gitkraken-desktop/agents.md
+++ b/gitkraken-desktop/agents.md
@@ -21,6 +21,10 @@ taxonomy:
 
 Use this page to learn how coding agents work in GitKraken Desktop and how to use **Agent Sessions View** to create, monitor, and manage coding agent sessions. Read this page if you want to use external coding agent CLIs such as Claude Code, Codex CLI, Copilot CLI, Gemini CLI, or OpenCode from inside GitKraken Desktop.
 
+<div class='callout callout--basic'>
+  <p><strong>On-premises note:</strong> GitKraken Desktop gives on-premises teams one place to run multiple coding agents. Agent availability depends on your security policy, network access, and which CLIs your organization allows. OpenCode and Gemini CLI can run in fully air-gapped environments when you point them to an internal model endpoint. Claude Code, Codex CLI, and Copilot CLI are also supported when your organization permits them and the required services are reachable from your environment.</p>
+</div>
+
 <img src='/wp-content/uploads/gkd-agents-panel-overview-20260414.png' class="help-center-img img-bordered" alt="GitKraken Desktop with Agent Sessions View open in the Left Panel. The view shows multiple agent session cards with status indicators alongside the commit graph and an active terminal session running a coding agent.">
 
 A **coding agent** is an external CLI that can work on code in a terminal session. In GitKraken Desktop, each **agent session** runs that CLI in its own [**worktree**](/gitkraken-desktop/worktrees/). **Agent Sessions View** shows those worktrees as agent-focused cards so you can start parallel work, monitor progress, and switch back when an agent needs attention.
@@ -149,6 +153,10 @@ GitKraken Desktop explicitly integrates with these supported coding agent CLIs:
 - [OpenCode](https://opencode.ai/download)
 
 GitKraken auto-detects installed CLIs. You can also add custom CLI arguments that GitKraken passes when it starts a coding agent session.
+
+In on-premises environments, do not assume every supported CLI will be available. The list in GitKraken Desktop depends on which CLIs are installed on the machine and which services your organization allows that machine to access.
+
+If you need fully air-gapped agent workflows, OpenCode and Gemini CLI can run against an internal model endpoint. Claude Code, Codex CLI, and Copilot CLI are supported when your organization permits them and the required services are available inside your environment.
 
 If you use a different coding agent, you can still open a session worktree and run that agent manually in the embedded terminal. The agent does not need to appear in the coding agent configuration for you to use that terminal workflow.
 

--- a/gitkraken-desktop/conflict-prevention.md
+++ b/gitkraken-desktop/conflict-prevention.md
@@ -37,7 +37,7 @@ Use this page to detect likely merge conflicts in GitKraken Desktop before they 
 
 ***
 
-<div class=’callout callout--warning’>
+<div class='callout callout--warning'>
   <p><strong>GitKraken On-Premise users:</strong> Target-branch conflict detection is available in Serverless and Self-Hosted Server deployments. The following features require cloud connectivity and are not available in those environments: Org Member conflict detection (requires a cloud GitKraken Org) and Cloud Patch sharing (requires gitkraken.dev).</p>
 </div>
 

--- a/gitkraken-desktop/faq.md
+++ b/gitkraken-desktop/faq.md
@@ -71,7 +71,9 @@ No. They show the same underlying worktrees. List view is reference-focused, whi
 
 ### Are Agent Sessions View and coding agent workflows available for on-prem customers?
 
-Yes. On-premises deployments use the same GitKraken Desktop client for local Desktop workflows such as worktrees, Agent Sessions View, and terminal-based coding agent workflows. Availability of cloud-dependent services still depends on the deployment and environment. For more information, see [Set Up GitKraken Self-Hosted Server (On-Premise)](/gitkraken-desktop/self-hosted/) and [GitKraken On-Premise Serverless (Stand-Alone) Setup](/gitkraken-desktop/serverless/).
+Yes. On-premises deployments use the same GitKraken Desktop client for local workflows such as worktrees, Agent Sessions View, and terminal-based coding agent workflows. However, do not assume every supported coding agent will be available in every on-premises environment.
+
+OpenCode and Gemini CLI can run in fully air-gapped environments when they are configured to use an internal model endpoint. Claude Code, Codex CLI, and Copilot CLI are also supported when your organization permits them and the required services are reachable from the environment. For more information, see [Coding Agents in GitKraken Desktop](/gitkraken-desktop/agents/), [Set Up GitKraken Self-Hosted Server (On-Premise)](/gitkraken-desktop/self-hosted/), and [GitKraken On-Premise Serverless (Stand-Alone) Setup](/gitkraken-desktop/serverless/).
 
 ---
 

--- a/gitkraken-desktop/how-to-install.md
+++ b/gitkraken-desktop/how-to-install.md
@@ -28,7 +28,7 @@ This installation guide explains how to install GitKraken Desktop on Windows, ma
 - Linux `.rpm`: RHEL 8+ or Fedora 39+
 - Linux support note: Other distributions may work but are not officially supported
 - Advanced features note: Git command-line tools are optional for basic use, but recommended for features such as the terminal, experimental tools, or Git LFS
-- Coding agent note: Coding agent CLIs such as Claude Code, Codex CLI, Copilot CLI, Gemini CLI, and OpenCode are installed separately from GitKraken Desktop
+- Coding agent note: Coding agent CLIs such as Claude Code, Codex CLI, Copilot CLI, Gemini CLI, and OpenCode are installed separately from GitKraken Desktop. In on-premises environments, availability depends on what your organization allows and can reach
 
 ***
 

--- a/gitkraken-desktop/preferences.md
+++ b/gitkraken-desktop/preferences.md
@@ -130,7 +130,7 @@ Configure your preferred editors, terminals, coding agent commands, and diff/mer
 - **External Editor**: Choose from VS Code, Atom, Sublime, IntelliJ, or custom path
 - **Default Terminal**: Launch from <kbd>File > Open Terminal</kbd> or <kbd>Alt</kbd>/<kbd>Option</kbd> + <kbd>T</kbd>
 - **Use Custom Terminal Command**: Example for PowerShell: `start "" "C:\Program Files\PowerShell\7\pwsh.exe" -noexit -command "cd %d"`
-- **Coding Agent**: Configure custom commands or arguments used when GitKraken Desktop starts a coding agent session. Supported coding agent CLIs such as Claude Code, Codex CLI, Copilot CLI, Gemini CLI, and OpenCode can be auto-detected based on what is installed on your machine. You can choose the coding agent for a session in the New Agent Session form. See [Coding Agents in GitKraken Desktop](/gitkraken-desktop/agents/).
+- **Coding Agent**: Configure custom commands or arguments used when GitKraken Desktop starts a coding agent session. Supported coding agent CLIs such as Claude Code, Codex CLI, Copilot CLI, Gemini CLI, and OpenCode can be auto-detected based on what is installed on your machine. You can choose the coding agent for a session in the New Agent Session form. In on-premises environments, available options depend on what your organization allows and can reach. See [Coding Agents in GitKraken Desktop](/gitkraken-desktop/agents/).
 
 <div class='callout callout--warning'>
   <p><strong>macOS Note:</strong> Use the executable file, not the .app, when selecting a custom editor.</p>

--- a/gitkraken-desktop/self-hosted.md
+++ b/gitkraken-desktop/self-hosted.md
@@ -61,7 +61,7 @@ The following feature categories are fully supported:
 | Category | Included | Notes |
 | --- | --- | --- |
 | **Core Git client** | All standard Git operations, including commits, branches, merges, rebases, diffs, stashing, tagging, interactive rebase, cherry pick (including multi-commit interactive cherry pick), worktrees, shallow clone, and undo or redo of rebase and cherry pick operations. | |
-| **Agent Sessions View and coding agent session workflows** | Agent Sessions View and worktree-based coding agent session workflows are available in the on-premises Desktop client. | Supported-agent integrations and status details depend on the client version and local environment. |
+| **Agent Sessions View and coding agent session workflows** | Agent Sessions View and worktree-based coding agent session workflows are available in the on-premises Desktop client. | Available coding agents depend on your security policy, internal approvals, client version, and local environment. OpenCode and Gemini CLI can run fully air-gapped against an internal model endpoint. Claude Code, Codex CLI, and Copilot CLI are supported when internally permitted and reachable. |
 | **Embedded terminal for manual coding agent workflows** | You can run coding agents manually in the embedded terminal, including agents that GitKraken Desktop does not explicitly integrate with. | See [GitKraken Terminal Guide](/gitkraken-desktop/terminal/). |
 | **Launchpad** | Track pull requests and issues in a single view and filter by repository, branch, milestone, or sprint. Launchpad works with the following on-premises integrations: GitHub Enterprise Server, GitLab Self-Managed, Bitbucket Server and Data Center, Azure DevOps Server, and Jira Data Center. | For a description of the differences between cloud and on-premises Launchpad, see [How On-Premise Launchpad differs from Cloud Launchpad](/gitkraken-desktop/gitkraken-launchpad/#how-on-premise-launchpad-differs-from-cloud-launchpad). |
 | **Local Workspaces** | Organize multiple local Git repositories in one view. You can see the branch status of each repository and run multi-repository actions, such as fetch and pull, from a single place. | Cloud Workspaces are not available. |
@@ -83,7 +83,7 @@ The following features require connectivity to GitKraken cloud services (`gitkra
 - Org Member conflict detection
 - Integrations with cloud-hosted services: GitHub.com, GitLab.com, Bitbucket.org, Azure DevOps cloud, Jira Cloud, and Trello
 
-Local Desktop workflows such as worktrees, Agent Sessions View, and terminal-based coding agent workflows remain available unless they depend on a cloud-only or otherwise unsupported external service.
+Local Desktop workflows such as worktrees, Agent Sessions View, and terminal-based coding agent workflows remain available unless they depend on a cloud-only or otherwise unsupported external service. For coding agents, availability depends on what your organization approves and what services are reachable from the environment.
 
 ### Feature support table
 
@@ -93,7 +93,7 @@ Local Desktop workflows such as worktrees, Agent Sessions View, and terminal-bas
 | Interactive Rebase | Yes | |
 | Multi-commit Cherry Pick | Yes | |
 | Worktrees | Yes | Requires client version 10.5.0 or later |
-| Agent Sessions View and coding agent session workflows | Yes | Available in the on-premises Desktop client; supported-agent integrations and status details depend on the client version and local environment |
+| Agent Sessions View and coding agent session workflows | Yes | Available in the on-premises Desktop client; available coding agents depend on security policy, internal approvals, client version, and local environment |
 | Embedded terminal for manual coding agent workflows | Yes | You can run coding agents manually in the embedded terminal |
 | Shallow Clone | Yes | |
 | Undo rebases, cherry picks, and AI Commit Compose | Yes | |

--- a/gitkraken-desktop/serverless.md
+++ b/gitkraken-desktop/serverless.md
@@ -76,7 +76,7 @@ The following feature categories are fully supported in Serverless:
 | Category | Included | Notes |
 | --- | --- | --- |
 | **Core Git client** | All standard Git operations, including commits, branches, merges, rebases, diffs, stashing, tagging, interactive rebase, cherry pick (including multi-commit interactive cherry pick), worktrees, shallow clone, and undo or redo of rebase and cherry pick operations. | |
-| **Agent Sessions View and coding agent session workflows** | Agent Sessions View and worktree-based coding agent session workflows are available in the on-premises Desktop client. | Supported-agent integrations and status details depend on the client version and local environment. |
+| **Agent Sessions View and coding agent session workflows** | Agent Sessions View and worktree-based coding agent session workflows are available in the on-premises Desktop client. | Available coding agents depend on your security policy, internal approvals, client version, and local environment. OpenCode and Gemini CLI can run fully air-gapped against an internal model endpoint. Claude Code, Codex CLI, and Copilot CLI are supported when internally permitted and reachable. |
 | **Embedded terminal for manual coding agent workflows** | You can run coding agents manually in the embedded terminal, including agents that GitKraken Desktop does not explicitly integrate with. | See [GitKraken Terminal Guide](/gitkraken-desktop/terminal/). |
 | **Launchpad** | Track pull requests and issues in a single view and filter by repository, branch, milestone, or sprint. Launchpad works with the following on-premises integrations: GitHub Enterprise Server, GitLab Self-Managed, Bitbucket Server and Data Center, Azure DevOps Server, and Jira Data Center. | For a description of the differences between cloud and on-premises Launchpad, see [How On-Premise Launchpad differs from Cloud Launchpad](/gitkraken-desktop/gitkraken-launchpad/#how-on-premise-launchpad-differs-from-cloud-launchpad). |
 | **Local Workspaces** | Organize multiple local Git repositories in one view. You can see the branch status of each repository and run multi-repository actions, such as fetch and pull, from a single place. | Cloud Workspaces are not available in Serverless. |
@@ -96,7 +96,7 @@ The following features require connectivity to GitKraken cloud services (`gitkra
 - Org Member conflict detection
 - Integrations with cloud-hosted services: GitHub.com, GitLab.com, Bitbucket.org, Azure DevOps cloud, Jira Cloud, and Trello
 
-Local Desktop workflows such as worktrees, Agent Sessions View, and terminal-based coding agent workflows remain available unless they depend on a cloud-only or otherwise unsupported external service.
+Local Desktop workflows such as worktrees, Agent Sessions View, and terminal-based coding agent workflows remain available unless they depend on a cloud-only or otherwise unsupported external service. For coding agents, availability depends on what your organization approves and what services are reachable from the environment.
 
 ### Feature support table
 
@@ -106,7 +106,7 @@ Local Desktop workflows such as worktrees, Agent Sessions View, and terminal-bas
 | Interactive Rebase | Yes | |
 | Multi-commit Cherry Pick | Yes | |
 | Worktrees | Yes | Requires version 10.5.0 or later |
-| Agent Sessions View and coding agent session workflows | Yes | Available in the on-premises Desktop client; supported-agent integrations and status details depend on the client version and local environment |
+| Agent Sessions View and coding agent session workflows | Yes | Available in the on-premises Desktop client; available coding agents depend on security policy, internal approvals, client version, and local environment |
 | Embedded terminal for manual coding agent workflows | Yes | You can run coding agents manually in the embedded terminal |
 | Shallow Clone | Yes | |
 | Undo rebases, cherry picks, and AI Commit Compose | Yes | |


### PR DESCRIPTION
Fixes #

Proposed Changes
- Introduces new callouts and updated sections to clarify on-premises availability, security policies, and air-gapped support for coding agents in the "Coding Agents in GitKraken Desktop" page.
- Harmonizes details regarding on-premises agent availability across various documentation pages, including FAQs, installation guides, preferences, and self-hosted/serverless feature tables.
- Emphasizes that OpenCode and Gemini CLI can operate in fully air-gapped environments, while other agents (Claude Code, Codex CLI, Copilot CLI) require network access and organizational approval.